### PR TITLE
Implémentation complète des tests dbt pour la validation des données

### DIFF
--- a/wild_dbt_project/models/staging/stg_customers.yml
+++ b/wild_dbt_project/models/staging/stg_customers.yml
@@ -6,5 +6,10 @@ models:
     columns:
       - name: customer_id
         description: "Unique identifier for customers"
+        tests:
+          - not_null
+          - unique
       - name: customer_name
         description: "Customer name"
+        tests:
+          - not_null

--- a/wild_dbt_project/models/staging/stg_orders.yml
+++ b/wild_dbt_project/models/staging/stg_orders.yml
@@ -6,9 +6,23 @@ models:
     columns:
       - name: order_id
         description: "Unique identifier for orders"
+        tests:
+          - not_null
+          - unique
       - name: customer_id
         description: "Foreign key to customer"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_customers')
+              field: customer_id
       - name: order_date
         description: "Date when the order was placed"
+        tests:
+          - not_null
       - name: order_status
         description: "Status of the order"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['completed', 'pending', 'cancelled']

--- a/wild_dbt_project/tests/order_dates_in_the_past.sql
+++ b/wild_dbt_project/tests/order_dates_in_the_past.sql
@@ -1,0 +1,9 @@
+-- Test pour vérifier que les dates de commande ne sont pas dans le futur
+with invalid_orders as (
+    select *
+    from {{ ref('stg_orders') }}
+    where order_date > current_date
+)
+select count(*)
+from invalid_orders
+having count(*) > 0


### PR DESCRIPTION
- Ajout de tests not_null et unique sur stg_customers (customer_id, customer_name)
- Ajout de tests not_null et unique sur stg_orders (order_id, customer_id, order_date, order_status)
- Ajout du test de relation customer_id entre stg_orders et stg_customers (bonus)
- Ajout du test accepted_values pour order_status (completed, pending, cancelled)
- Création du test personnalisé order_dates_in_the_past pour vérifier les dates
- Tous les 11 tests passent avec succès (dbt test)